### PR TITLE
fix: 404 links in docs

### DIFF
--- a/src/lib_sapling/README.md
+++ b/src/lib_sapling/README.md
@@ -1,6 +1,6 @@
 This OCaml library implements the Sapling protocol for privacy-preserving
 transactions as described in its
-[specification](https://github.com/zcash/zips/blob/master/protocol/sapling.pdf),
+[specification](https://github.com/zcash/zips/blob/main/rendered/protocol/sapling.pdf),
 version 2020.1.2.
 
 A large part of the functionalities are implemented by the

--- a/src/lib_sapling/core_sig.ml
+++ b/src/lib_sapling/core_sig.ml
@@ -24,7 +24,7 @@
 (*****************************************************************************)
 
 (** Reference specification is version 2020.1.2
-    https://github.com/zcash/zips/blob/master/protocol/sapling.pdf
+    https://github.com/zcash/zips/blob/main/rendered/protocol/sapling.pdf
  *)
 
 (** Each instance of the Sapling protocol should be identified by a unique string


### PR DESCRIPTION
Hi! I updated outdated links to the Sapling protocol specification:  
 
- **Old link:** `https://github.com/zcash/zips/blob/master/protocol/sapling.pdf`  
- **New link:** `https://github.com/zcash/zips/blob/main/rendered/protocol/sapling.pdf`  
